### PR TITLE
Fix deserialization of OrderRequest and nested POJOs

### DIFF
--- a/src/main/java/com/tcc/serveme/api/dto/OrderRequest.java
+++ b/src/main/java/com/tcc/serveme/api/dto/OrderRequest.java
@@ -1,5 +1,6 @@
 package com.tcc.serveme.api.dto;
 
-import java.util.List;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.tcc.serveme.api.model.OrderTicket;
 
-public record OrderRequest(int tableNumber, String waiter, List<Integer> items, String notes) {}
+public record OrderRequest(String waiter, @JsonProperty("orderTicket") OrderTicket ordertTicket, String notes) {}

--- a/src/main/java/com/tcc/serveme/api/model/Client.java
+++ b/src/main/java/com/tcc/serveme/api/model/Client.java
@@ -20,4 +20,11 @@ public class Client {
         this.name = name;
     }
 
+    @Override
+    public String toString() {
+        return "Client [name = " + getName() + "]";
+    }
+
+    
+
 }

--- a/src/main/java/com/tcc/serveme/api/model/Client.java
+++ b/src/main/java/com/tcc/serveme/api/model/Client.java
@@ -1,10 +1,14 @@
 package com.tcc.serveme.api.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class Client {
 
     private String name;
 
-    public Client(String name) {
+     @JsonCreator
+    public Client(@JsonProperty("name") String name) {
         this.name = name;
     }
 

--- a/src/main/java/com/tcc/serveme/api/model/Order.java
+++ b/src/main/java/com/tcc/serveme/api/model/Order.java
@@ -34,4 +34,11 @@ public class Order {
         return quantity * product.getPrice();
     }
 
+    @Override
+    public String toString() {
+        return "Order [product = " + getProduct() + ", quantity = " + getQuantity() + "]";
+    }
+
+    
+
 }

--- a/src/main/java/com/tcc/serveme/api/model/Order.java
+++ b/src/main/java/com/tcc/serveme/api/model/Order.java
@@ -1,11 +1,15 @@
 package com.tcc.serveme.api.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class Order {
 
     private Product product;
     private Integer quantity;
 
-    public Order(Product product, Integer quantity) {
+    @JsonCreator
+    public Order(@JsonProperty("product") Product product, @JsonProperty("quantity") Integer quantity) {
         this.product = product;
         this.quantity = quantity;
     }

--- a/src/main/java/com/tcc/serveme/api/model/OrderTicket.java
+++ b/src/main/java/com/tcc/serveme/api/model/OrderTicket.java
@@ -2,6 +2,8 @@ package com.tcc.serveme.api.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.tcc.serveme.api.model.enums.Status;
 
@@ -13,7 +15,13 @@ public class OrderTicket {
     private Client client;
     private List<Order> order = new ArrayList<>();
     
-    public OrderTicket(Integer id, Integer table, Client client, List<Order> order) {
+     @JsonCreator
+    public OrderTicket(
+        @JsonProperty("id") Integer id,
+        @JsonProperty("table") Integer table,
+        @JsonProperty("client") Client client,
+        @JsonProperty("order") List<Order> order
+    ) {
         this.id = id;
         this.table = table;
         this.status = Status.OPEN;

--- a/src/main/java/com/tcc/serveme/api/model/OrderTicket.java
+++ b/src/main/java/com/tcc/serveme/api/model/OrderTicket.java
@@ -84,6 +84,14 @@ public class OrderTicket {
     public void closeOrderticket(){
         status = Status.CLOSED;
     }
+
+    @Override
+    public String toString() {
+        return "OrderTicket [id = " + getId() + ", table = " + getTable() + ", status = " + getStatus() + ", client = " + getClient() + ", order = "
+                + getOrder() + "]";
+    }
+
+    
     
 
 }

--- a/src/main/java/com/tcc/serveme/api/model/Product.java
+++ b/src/main/java/com/tcc/serveme/api/model/Product.java
@@ -30,4 +30,10 @@ public class Product {
         this.price = price;
     }
 
+    @Override
+    public String toString() {
+        return "Product [nameProduct = " + getNameProduct() + ", price = " + getPrice() + "]";
+    }
+
+    
 }

--- a/src/main/java/com/tcc/serveme/api/model/Product.java
+++ b/src/main/java/com/tcc/serveme/api/model/Product.java
@@ -1,21 +1,25 @@
 package com.tcc.serveme.api.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class Product {
 
-    protected String name;
+    protected String nameProduct;
     protected Double price;
     
-    public Product(String name, Double price) {
-        this.name = name;
+    @JsonCreator
+    public Product(@JsonProperty("nameProduct") String nameProduct, @JsonProperty("price") Double price) {
+        this.nameProduct = nameProduct;
         this.price = price;
     }
 
-    public String getName() {
-        return name;
+    public String getNameProduct() {
+        return nameProduct;
     }
 
-    public void setName(String name) {
-        this.name = name;
+    public void setNameProduct(String nameProduct) {
+        this.nameProduct = nameProduct;
     }
 
     public Double getPrice() {


### PR DESCRIPTION
- Fixed JSON deserialization of OrderRequest in Spring Boot.
- Added @JsonProperty("orderTicket") to the OrderRequest record to match the JSON field name.
- Added @JsonCreator + @JsonProperty to nested POJOs (Client, Order, Product, Client) so Jackson can instantiate them correctly.
- Ensured that the 'order' field in OrderTicket is always deserialized as a list, even with a single item.
- Manual testing confirmed that OrderRequest is now correctly populated when sending JSON via Postman.
- Added toString() methods to OrderRequest and all nested POJOs for easier logging and debugging.